### PR TITLE
Convert links in readmes to html

### DIFF
--- a/challenges/space-navigator/1/README.md
+++ b/challenges/space-navigator/1/README.md
@@ -19,7 +19,7 @@ Can you find the password?
 Once you have obtained it we can control the navigation console.
 
 We got parts of the configuration file of the welcome menu application.
-It seems like a [Tauri](https://tauri.app/) application:
+It seems like a <a href="https://tauri.app/" rel="noopener noreferrer" target="_blank">Tauri</a> application.
 
 ```json
 {
@@ -41,6 +41,6 @@ It seems like a [Tauri](https://tauri.app/) application:
 }
 ```
 
-You can find out more about this configuration file at the Tauri [documentation](https://tauri.app/v1/api/config/).
+You can find out more about this configuration file at the Tauri <a href="https://tauri.app/v1/api/config/" rel="noopener noreferrer" target="_blank">documentation</a>.
 The `$RESOURCE` path seems to be different for each operating system.
 Luckily this path is handled by Tauri and you can use relative paths like `logs/`.

--- a/challenges/space-navigator/2/README.md
+++ b/challenges/space-navigator/2/README.md
@@ -33,7 +33,7 @@ We got the interesting part of the configuration file of the navigator menu appl
 }
 ```
 
-The navigation application seems to have custom functions outside of the documented [Tauri API](https://tauri.app/v1/api/js/).
+The navigation application seems to have custom functions outside of the documented <a href="https://tauri.app/v1/api/js/" rel="noopener noreferrer" target="_blank">Tauri API</a>.
 It seems like we already know where the coordinates are but can not access them.
 There seems some functionality hidden in some elements to access them via the frontend.
 We heard that there is some shortcut to open the `developer tools`, maybe it is documented somewhere or you already know it.

--- a/challenges/space-navigator/3/README.md
+++ b/challenges/space-navigator/3/README.md
@@ -29,12 +29,12 @@ We should infer where the cordinates need to be written to from the configuratio
 ```
 
 There seems like an internal API called
-[writeTextFile](https://tauri.app/v1/api/js/fs#writetextfile),
+<a href="https://tauri.app/v1/api/js/fs#writetextfile" rel="noopener noreferrer" target="_blank">writeTextFile</a>,
 which seems perfect to insert the coordinates into the current coordinates folder.
 We sadly can not figure out how to call it directly. It seems like the function signature
 was wrapped around `writeFile`.
 
-We found the internal rust api [code](https://github.com/tauri-apps/tauri/blob/2c7d683ae39716f06298849d8a01f81c6fd6f153/core/tauri/src/endpoints/file_system.rs#L76) for `writeFile`:
+We found the internal rust api <a href="https://github.com/tauri-apps/tauri/blob/2c7d683ae39716f06298849d8a01f81c6fd6f153/core/tauri/src/endpoints/file_system.rs#L76" rel="noopener noreferrer" target="_blank">code</a> for `writeFile`:
 
 ```rust
   /// The write file API.
@@ -51,4 +51,4 @@ triggered manually and where no convenience code was added in the frontend code:
 
 `await window.__TAURI_INVOKE__("tauri",{__tauriModule:"Shell",message:{cmd:"open",path: "https://tauri.app"}})`
 
-More explanation is mentioned in the [Tauri Command Documentation](https://tauri.app/v1/guides/features/command/).
+More explanation is mentioned in the <a href="https://tauri.app/v1/guides/features/command/" rel="noopener noreferrer" target="_blank">Tauri Command Documentation</a>.


### PR DESCRIPTION
This converts links to html links, so they will be opened with the system browser instead.