### PR TITLE
Clarify package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ To reiterate, please be aware that Broken Navigator is an intentionally vulnerab
     ```sh
     cd challenges/space-navigator/1
     npm run tauri dev
+    # or
+    cargo tauri dev
     ```
 
 Each challenge is located within the `challenges/<component>/[1-x]` subdirectories. While challenges can generally be solved independently, some may require knowledge from previous ones.


### PR DESCRIPTION
For some reason, running the command from `cargo` instead of `npm` puts me in an infinite loop.

Running this via `npm` behaves as expected.

<details open>
<summary><h2>With Cargo</h2></summary>

https://github.com/crabnebula-dev/broken-navigator/assets/125391648/2f48e190-5961-4223-ba22-fa1f3502f0c3

</details>

<details>
<summary><h2>With npm</h2></summary>

https://github.com/crabnebula-dev/broken-navigator/assets/125391648/11b16957-a16c-4aa4-8f46-90aadd9918ed

</details>