### PR TITLE
Fix Build Loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To reiterate, please be aware that Broken Navigator is an intentionally vulnerab
     cd challenges/space-navigator/1
     npm run tauri dev
     # or
-    cargo tauri dev --no-watch
+    cargo tauri dev
     ```
 
 Each challenge is located within the `challenges/<component>/[1-x]` subdirectories. While challenges can generally be solved independently, some may require knowledge from previous ones.

--- a/challenges/space-navigator/1/.taurignore
+++ b/challenges/space-navigator/1/.taurignore
@@ -1,0 +1,1 @@
+src-tauri/logs/

--- a/challenges/space-navigator/2/.taurignore
+++ b/challenges/space-navigator/2/.taurignore
@@ -1,0 +1,1 @@
+src-tauri/navigation/


### PR DESCRIPTION
As Tauri's `cargo tauri dev` command uses a filesystem watcher for hot reloading, it conflicts with our template files changed on build in `src-tauri` and causes endless build loops on Windows and MacOS. As a stopgap we changed documentation in #28 but now have added a `.taurignore` to the challenges with dynamic file generation.

Still to investigate is why this loop behavior did not occur on Linux but the main issue is resolved.