### PR TITLE
Add Potential Fix to Internal Doc

### DIFF
--- a/challenges/space-navigator/3/INTERNAL.md
+++ b/challenges/space-navigator/3/INTERNAL.md
@@ -38,3 +38,9 @@ Access to the the write file Tauri command.
 1. Open developer tools with system shortcut (`shift` or `cmd``+crtl+i`)
 2. Execute `window.__TAURI_INVOKE__("tauri",{__tauriModule:"Fs",message:{cmd:"writeFile",path: "navigation/active/Earth.cord", contents: [102, 108, 97, 103] , options: { dir: 17}}})` via console
 3. Click button to retrieve flag
+
+## Potential Fix
+
+It seems like the developer forgot to remove access to the file from the allowlist.
+To fix the behavior just removing the scope from the `fs` allowlist module will prevent
+the `fs` module to access the file, even if the command is still enabled.

--- a/challenges/space-navigator/4/INTERNAL.md
+++ b/challenges/space-navigator/4/INTERNAL.md
@@ -31,3 +31,17 @@ Load the navigation data into the backend system.
 ## Privileges
 
 Access to the custom `correct_coordinates` Tauri command.
+
+## Potential Fix
+
+The application exposed the command, where the developer did not consider the `scope`
+from the `fs` plugin and just gave "write" access to a file which should not be writable
+in the normal flow of the app.
+
+> Note: In this instance the rust function has no write to disk functionality,
+> as we don't want to write to players file system and to allow the challenge to be played
+> in `read-only` file systems. The function would normally use `std:fs` to write to a file.
+
+To fix this unintended behavior the `correct_coordinates` function could check the 
+[`FsScope`](https://docs.rs/tauri/1.6.0/tauri/scope/struct.FsScope.html) and match the
+fileystem access or only operate in folders, where it should be able to write into.


### PR DESCRIPTION
Adds potential fixes to challenge 3&4, which explain what would be intended and how this could be achieved.